### PR TITLE
Correction des URLs des images du S3

### DIFF
--- a/backend/lib/projets-validator.js
+++ b/backend/lib/projets-validator.js
@@ -233,9 +233,8 @@ const reutilisationsSchemaCreation = Joi.object({
   imageKey: Joi.string().allow(null).messages({
     'string.base': 'La clé de l’image doit être une chaine de caractères'
   }),
-  imageURL: Joi.string().uri().allow(null).messages({
-    'string.base': 'L’URL de l’image doit être une chaine de caractères',
-    'string.uri': 'L’URL de l’image n’est pas valide'
+  imageURL: Joi.string().allow(null).messages({
+    'string.base': 'L’URL de l’image doit être une chaine de caractères'
   })
 })
 
@@ -475,9 +474,8 @@ const reutilisationsSchemaUpdate = Joi.object().keys({
   imageKey: Joi.string().allow(null).messages({
     'string.base': 'La clé de l’image doit être une chaine de caractères'
   }),
-  imageURL: Joi.string().uri().allow(null).messages({
-    'string.base': 'L’URL de l’image doit être une chaine de caractères',
-    'string.uri': 'L’URL de l’image n’est pas valide'
+  imageURL: Joi.string().allow(null).messages({
+    'string.base': 'L’URL de l’image doit être une chaine de caractères'
   })
 }).messages({
   'object.unknown': 'Une clé de l’objet est invalide'

--- a/components/projet/reutilisations-section.js
+++ b/components/projet/reutilisations-section.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import Image from 'next/image'
+import {s3ImageUrl} from 'utils/s3-image-url'
 
 const Reutilisations = ({reutilisations}) => (
   <>
@@ -35,7 +36,11 @@ const Reutilisations = ({reutilisations}) => (
                   <div className='fr-card__img'>
                     <Image
                       className='fr-responsive-img'
-                      src={reutilisation.imageURL ?? '/images/illustrations/blog_fallback.svg'}
+                      src={
+                        reutilisation.imageURL
+                          ? s3ImageUrl(reutilisation.imageURL)
+                          : '/images/illustrations/blog_fallback.svg'
+                      }
                       alt={'Illustration de ' + reutilisation.titre}
                       height={250}
                       width={500}

--- a/components/suivi-form/reutilisations/reutilisation-card.js
+++ b/components/suivi-form/reutilisations/reutilisation-card.js
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types'
 import Image from 'next/image'
 
+import {s3ImageUrl} from '../../../utils/s3-image-url.js'
+
 import colors from '@/styles/colors.js'
 
 const ReutilisationCard = ({titre, lien, description, imageURL, isDisabled, handleDelete, handleEdition}) => (
@@ -23,7 +25,7 @@ const ReutilisationCard = ({titre, lien, description, imageURL, isDisabled, hand
           {imageURL ? (
             <Image
               className='fr-responsive-img'
-              src={imageURL ?? '/images/illustrations/blog_fallback.svg'}
+              src={imageURL ? s3ImageUrl(imageURL) : '/images/illustrations/blog_fallback.svg'}
               alt={'Illustration de ' + titre}
               height={250}
               width={500}

--- a/components/suivi-form/reutilisations/reutilisation-form.js
+++ b/components/suivi-form/reutilisations/reutilisation-form.js
@@ -73,7 +73,7 @@ const ReutilisationForm = ({initialValues, isReutilisationExists, editCode, proj
       setMessage(data.message)
     }
 
-    setImageURL(data.imageURL)
+    setImageURL(data?.imageURL?.replaceAll(S3_URL, ''))
     setImageKey(data.imageKey)
     setIsUploading(false)
   }

--- a/components/suivi-form/reutilisations/reutilisation-form.js
+++ b/components/suivi-form/reutilisations/reutilisation-form.js
@@ -1,12 +1,15 @@
 import {useState} from 'react'
 import PropTypes from 'prop-types'
 import Image from 'next/image'
+import {s3ImageUrl} from 'utils/s3-image-url'
 import {useInput} from '@/hooks/input.js'
 
 import colors from '@/styles/colors.js'
 
 import TextInput from '@/components/text-input.js'
 import Button from '@/components/button.js'
+
+const S3_URL = process.env.NEXT_PUBLIC_IMAGES_DOMAIN
 
 const ReutilisationForm = ({initialValues, isReutilisationExists, editCode, projectId, onSubmit, onCancel}) => {
   const [file, setFile] = useState(null)
@@ -169,7 +172,7 @@ const ReutilisationForm = ({initialValues, isReutilisationExists, editCode, proj
             <div className='fr-col-12 fr-col-md-4'>
               <Image
                 className='fr-responsive-img'
-                src={imageURL}
+                src={s3ImageUrl(imageURL)}
                 alt={'Illustration de ' + titre}
                 height={250}
                 width={500}

--- a/utils/s3-image-url.js
+++ b/utils/s3-image-url.js
@@ -1,0 +1,13 @@
+const URL = process.env.NEXT_PUBLIC_IMAGES_DOMAIN
+
+// Fonction pour prendre en charge les images provenant du S3:
+// Certaines images sont stockées en base avec l'URL complète du S3,
+// après modification, les nouvelles images uploadées n'ont plus l'URL.
+
+export function s3ImageUrl(imageURL) {
+  if (imageURL.includes(URL)) {
+    return imageURL
+  }
+
+  return URL + imageURL
+}


### PR DESCRIPTION
Lorsqu'on ajoute une image depuis le formulaire, l'URL complète de l'image est stockée dans la base, ce qui pose un problème si on doit changer de prestataire.

Ces modifications permettent d'enregistrer en base uniquement la clé de l'image.

- Suppression de l'URL lors de l'enregistrement en base
- Modification de la validation du projet
- Ajout d'une fonction pour prendre en compte les anciennes et nouvelles clés/urls des images